### PR TITLE
Добавил body для метода DELETE

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -134,7 +134,7 @@ class RequestOptions {
         const method = this.http_options.method = options.method.toUpperCase();
 
         this.body = null;
-        if ( options.body && ( method === 'POST' || method === 'PUT' || method === 'PATCH' ) ) {
+        if ( options.body && ( method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE') ) {
             if ( Buffer.isBuffer( options.body ) ) {
                 this.body = options.body;
                 this.set_content_type( 'application/octet-stream' );

--- a/tests/request.test.js
+++ b/tests/request.test.js
@@ -246,7 +246,7 @@ describe( 'request', () => {
             expect( Buffer.compare( BODY, body ) ).toBe( 0 );
         } );
 
-        it.each( [ 'POST', 'PUT', 'PATCH' ] )( '%j, body is a string', async ( method ) => {
+        it.each( [ 'POST', 'PUT', 'PATCH', 'DELETE' ] )( '%j, body is a string', async ( method ) => {
             const path = get_path();
 
             const BODY = 'Привет!';
@@ -269,7 +269,7 @@ describe( 'request', () => {
             expect( body.toString() ).toBe( BODY );
         } );
 
-        it.each( [ 'POST', 'PUT', 'PATCH' ] )( '%j, body is a string, custom content-type', async ( method ) => {
+        it.each( [ 'POST', 'PUT', 'PATCH', 'DELETE' ] )( '%j, body is a string, custom content-type', async ( method ) => {
             const path = get_path();
 
             const BODY = 'div { color: red; }';
@@ -295,7 +295,7 @@ describe( 'request', () => {
             expect( body.toString() ).toBe( BODY );
         } );
 
-        it.each( [ 'POST', 'PUT', 'PATCH' ] )( '%j, body is an object', async ( method ) => {
+        it.each( [ 'POST', 'PUT', 'PATCH', 'DELETE' ] )( '%j, body is an object', async ( method ) => {
             const path = get_path();
 
             const BODY = {
@@ -322,7 +322,7 @@ describe( 'request', () => {
             expect( body.toString() ).toBe( body_string );
         } );
 
-        it.each( [ 'POST', 'PUT', 'PATCH' ] )( '%j, body is an object, content-type is application/json', async ( method ) => {
+        it.each( [ 'POST', 'PUT', 'PATCH', 'DELETE' ] )( '%j, body is an object, content-type is application/json', async ( method ) => {
             const path = get_path();
 
             const BODY = {


### PR DESCRIPTION
По спеке не рекомендуется, но явного запрета нет, поэтому предлагаю передавать, так как есть бэкенды, которые ожидают body на вход

https://tools.ietf.org/html/rfc7231#section-4.3.5

> A payload within a DELETE request message has no defined semantics;
>    sending a payload body on a DELETE request might cause some existing
>    implementations to reject the request.