### PR TITLE
Вернуть произвольные поля из дескриптовой ошибки

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -38,20 +38,23 @@ function create_error( error, id ) {
     }
 
     if ( error instanceof Error ) {
+        const { name, message, stack, errno, code, syscall, ...rest } = error;
+
         const _error = {
-            id: id || error.name,
-            message: error.message,
-            stack: error.stack,
+            ...rest,
+            id: id || name,
+            message: message,
+            stack: stack,
         };
 
-        if ( error.errno ) {
-            _error.errno = error.errno;
+        if ( errno ) {
+            _error.errno = errno;
         }
-        if ( error.code ) {
-            _error.code = error.code;
+        if ( code ) {
+            _error.code = code;
         }
-        if ( error.syscall ) {
-            _error.syscall = error.syscall;
+        if ( syscall ) {
+            _error.syscall = syscall;
         }
 
         error = _error;

--- a/tests/options.error.test.js
+++ b/tests/options.error.test.js
@@ -71,6 +71,27 @@ describe( 'options.error', () => {
         expect( result ).toBe( error_2 );
     } );
 
+    it( 'returns error with custom params', async () => {
+        const error_1 = de.error( {
+            id: 'ERROR_1',
+        } );
+        const error_custom_params = de.error( {
+            id: 'ERROR_CUSTOM',
+            details: {
+                retryAfter: 3000,
+            },
+        } );
+        const block = get_error_block( error_1 )( {
+            options: {
+                error: () => error_custom_params,
+            },
+        } );
+
+        const result = await de.run( block );
+
+        expect( result ).toBe( error_custom_params );
+    } );
+
     it( 'throws ReferenceError', async () => {
         const error_1 = de.error( {
             id: 'ERROR_1',


### PR DESCRIPTION
В проекте у ошибок есть дополнительное поле чтобы помочь приложению справиться с ними, например, `details: { retryDelay: 1000, reason: 'SOME_REASON', location: '/' }` — приложение читает содержимое details и в зависимости от значений принимает решение что делать дальше. Предлагаю расширить св-ва ошибки.