### PR TITLE
Typed params validation in nested blocks

### DIFF
--- a/docs/typescript-examples/array.ts
+++ b/docs/typescript-examples/array.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import * as de from '../../lib';
+import { blockNeedsA, blockNeedsB, ParamsA, ParamsAB } from './shared';
 
 //  ---------------------------------------------------------------------------------------------------------------  //
 
@@ -155,3 +156,28 @@ de.run(bfn3, {
     .then((result) => {
         console.log(result[ 0 ], result[ 1 ]);
     });
+
+//  ---------------------------------------------------------------------------------------------------------------  //
+// Тут проверяем, что есть ошибка при несовпадении параметров и нету ошибки при валидных параметрах вложенных блоков
+// @ts-expect-error тут должна быть DescriptParamsError
+de.func({
+    block: ({ params }: { params: ParamsA }) => {
+        void params;
+
+        return de.array({
+            block: [ blockNeedsA, blockNeedsB ],
+        });
+    },
+});
+
+de.func({
+    block: ({ params }: { params: ParamsAB }) => {
+        void params;
+
+        return de.array({
+            block: [ blockNeedsA, blockNeedsB ],
+        });
+    },
+});
+
+//  ---------------------------------------------------------------------------------------------------------------  //

--- a/docs/typescript-examples/first.ts
+++ b/docs/typescript-examples/first.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import * as de from '../../lib';
+import { blockNeedsA, blockNeedsB, ParamsA, ParamsAB } from './shared';
 
 //  ---------------------------------------------------------------------------------------------------------------  //
 
@@ -164,3 +165,28 @@ de.run(bfn3, {
     .then((result) => {
         console.log(result);
     });
+
+//  ---------------------------------------------------------------------------------------------------------------  //
+// Тут проверяем, что есть ошибка при несовпадении параметров и нету ошибки при валидных параметрах вложенных блоков
+// @ts-expect-error тут должна быть DescriptParamsError
+de.func({
+    block: ({ params }: { params: ParamsA }) => {
+        void params;
+
+        return de.first({
+            block: [ blockNeedsA, blockNeedsB ],
+        });
+    },
+});
+
+de.func({
+    block: ({ params }: { params: ParamsAB }) => {
+        void params;
+
+        return de.first({
+            block: [ blockNeedsA, blockNeedsB ],
+        });
+    },
+});
+
+//  ---------------------------------------------------------------------------------------------------------------  //

--- a/docs/typescript-examples/func.ts
+++ b/docs/typescript-examples/func.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import * as de from '../../lib';
+import { blockNeedsA, blockNeedsAB, blockNeedsB, ParamsA, ParamsAB } from './shared';
 
 interface ParamsIn1 {
     id: string;
@@ -126,3 +127,27 @@ de.run(block4, {
     .then((result) => {
         console.log(result);
     });
+
+//  ---------------------------------------------------------------------------------------------------------------  //
+// Тут проверяем, что есть ошибка при несовпадении параметров и нету ошибки при валидных параметрах вложенных блоков
+// @ts-expect-error тут должна быть DescriptParamsError
+de.func({
+    block: ({ params }: { params: ParamsA }) =>
+        params.a === 'special' ? blockNeedsA : blockNeedsB,
+});
+
+de.func({
+    block: ({ params }: { params: ParamsAB }) =>
+        params.a === 'special' ? blockNeedsA : blockNeedsB,
+});
+
+de.run(blockNeedsAB, {
+    params: { a: 'hello', b: 42 },
+});
+
+de.run(blockNeedsAB, {
+    // @ts-expect-error тут должна быть ошибка 'b' is declared here.
+    params: { a: 'hello' },
+});
+
+//  ---------------------------------------------------------------------------------------------------------------  //

--- a/docs/typescript-examples/object.ts
+++ b/docs/typescript-examples/object.ts
@@ -96,7 +96,7 @@ const block2 = de.http({
 
 const block2Func = de.func({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    block: ({ params }: { params: InferParamsInFromBlock<typeof block1> & { p1: number } }) => block2,
+    block: ({ params }: { params: InferParamsInFromBlock<typeof block2> & { p1: number } }) => block2,
     // block: () => block2,
     options: {
         after: ({ result }) => {
@@ -111,11 +111,8 @@ const block2Func = de.func({
 
 de.run(block2Func, {
     params: {
-        id1: '67890',
         p1: 1,
-        payload: {
-            card: {},
-        },
+        id2: 578923,
     },
 })
     .then((result) => {
@@ -166,12 +163,8 @@ const block3 = de.object({
 
 de.run(block3, {
     params: {
-        id1: '12345',
         id2: 67890,
         p1: 1,
-        payload: {
-            card: {},
-        },
     },
 })
     .then((result) => {
@@ -230,12 +223,8 @@ const block5 = block3.extend({
 
 de.run(block4, {
     params: {
-        id1: '12345',
         id2: 67890,
         p1: 1,
-        payload: {
-            card: {},
-        },
     },
 })
     .then((result) => {
@@ -244,12 +233,8 @@ de.run(block4, {
 
 de.run(block5, {
     params: {
-        id1: '12345',
         id2: 67890,
         p1: 1,
-        payload: {
-            card: {},
-        },
     },
 })
     .then((result) => {

--- a/docs/typescript-examples/object.ts
+++ b/docs/typescript-examples/object.ts
@@ -2,6 +2,7 @@
 
 import * as de from '../../lib';
 import type { DescriptHttpBlockResult, InferParamsInFromBlock } from '../../lib/types';
+import { blockNeedsA, blockNeedsB, ParamsA, ParamsAB } from './shared';
 
 //  ---------------------------------------------------------------------------------------------------------------  //
 
@@ -240,3 +241,28 @@ de.run(block5, {
     .then((result) => {
         console.log(result);
     });
+
+//  ---------------------------------------------------------------------------------------------------------------  //
+// Тут проверяем, что есть ошибка при несовпадении параметров и нету ошибки при валидных параметрах вложенных блоков
+// @ts-expect-error тут должна быть DescriptParamsError
+de.func({
+    block: ({ params }: { params: ParamsA }) => {
+        void params;
+
+        return de.object({
+            block: { blockNeedsA, blockNeedsB },
+        });
+    },
+});
+
+de.func({
+    block: ({ params }: { params: ParamsAB }) => {
+        void params;
+
+        return de.object({
+            block: { blockNeedsA, blockNeedsB },
+        });
+    },
+});
+
+//  ---------------------------------------------------------------------------------------------------------------  //

--- a/docs/typescript-examples/pipe.ts
+++ b/docs/typescript-examples/pipe.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import * as de from '../../lib';
+import { blockNeedsA, blockNeedsB, ParamsA, ParamsAB } from './shared';
 
 //  ---------------------------------------------------------------------------------------------------------------  //
 
@@ -164,3 +165,28 @@ de.run(bfn3, {
     .then((result) => {
         console.log(result);
     });
+
+//  ---------------------------------------------------------------------------------------------------------------  //
+// Тут проверяем, что есть ошибка при несовпадении параметров и нету ошибки при валидных параметрах вложенных блоков
+// @ts-expect-error тут должна быть DescriptParamsError
+de.func({
+    block: ({ params }: { params: ParamsA }) => {
+        void params;
+
+        return de.pipe({
+            block: [ blockNeedsA, blockNeedsB ],
+        });
+    },
+});
+
+de.func({
+    block: ({ params }: { params: ParamsAB }) => {
+        void params;
+
+        return de.pipe({
+            block: [ blockNeedsA, blockNeedsB ],
+        });
+    },
+});
+
+//  ---------------------------------------------------------------------------------------------------------------  //

--- a/docs/typescript-examples/shared.ts
+++ b/docs/typescript-examples/shared.ts
@@ -1,0 +1,32 @@
+import * as de from '../../lib';
+
+export interface ParamsA {
+    a: string;
+}
+
+export interface ParamsB {
+    b: number;
+}
+
+export interface ParamsAB {
+    a: string;
+    b: number;
+}
+
+export const blockNeedsA = de.http({
+    block: {
+        pathname: ({ params }: { params: ParamsA }) => `/a/${ params.a }`,
+    },
+});
+
+export const blockNeedsB = de.http({
+    block: {
+        pathname: ({ params }: { params: ParamsB }) => `/b/${ params.b }`,
+    },
+});
+
+export const blockNeedsAB = de.http({
+    block: {
+        pathname: ({ params }: { params: ParamsAB }) => `/b/${ params.b }/${ params.a }`,
+    },
+});

--- a/lib/functionBlock.ts
+++ b/lib/functionBlock.ts
@@ -2,20 +2,9 @@ import BaseBlock from './block';
 import type { DepAccessor, DescriptBlockDeps } from './depsDomain';
 import DepsDomain, { createDepAccessor } from './depsDomain';
 import { createError, ERROR_ID } from './error';
-import type { BlockResultOut, DescriptBlockOptions, DescriptParamsError, InferParamsOutFromBlock } from './types';
+import type { BlockResultOut, DescriptBlockOptions, InferParamsOutFromBlock } from './types';
 import type ContextClass from './context';
 import type Cancel from './cancel';
-
-type NestedBlockParamsConstraint<T, Params> =
-    [ unknown ] extends [ Params ]
-        ? T
-        : T extends BaseBlock<any, any, any, any, any, any, any, any, any, infer BParams>
-            ? unknown extends BParams
-                ? T
-                : [ Params ] extends [ BParams ]
-                    ? T
-                    : DescriptParamsError<BParams, Params>
-            : T;
 
 export type FunctionBlockDefinition<
     Context,
@@ -29,7 +18,7 @@ export type FunctionBlockDefinition<
     generateId: DepsDomain['generateId'];
     cancel: Cancel;
     blockCancel: Cancel;
-}) => Promise<NestedBlockParamsConstraint<BlockResult, Params>> | NestedBlockParamsConstraint<BlockResult, Params>;
+}) => Promise<BlockResult> | BlockResult;
 
 class FunctionBlock<
     Context,

--- a/lib/functionBlock.ts
+++ b/lib/functionBlock.ts
@@ -2,9 +2,20 @@ import BaseBlock from './block';
 import type { DepAccessor, DescriptBlockDeps } from './depsDomain';
 import DepsDomain, { createDepAccessor } from './depsDomain';
 import { createError, ERROR_ID } from './error';
-import type { BlockResultOut, DescriptBlockOptions, InferParamsOutFromBlock } from './types';
+import type { BlockResultOut, DescriptBlockOptions, DescriptParamsError, InferParamsOutFromBlock } from './types';
 import type ContextClass from './context';
 import type Cancel from './cancel';
+
+type NestedBlockParamsConstraint<T, Params> =
+    [ unknown ] extends [ Params ]
+        ? T
+        : T extends BaseBlock<any, any, any, any, any, any, any, any, any, infer BParams>
+            ? unknown extends BParams
+                ? T
+                : [ Params ] extends [ BParams ]
+                    ? T
+                    : DescriptParamsError<BParams, Params>
+            : T;
 
 export type FunctionBlockDefinition<
     Context,
@@ -18,7 +29,7 @@ export type FunctionBlockDefinition<
     generateId: DepsDomain['generateId'];
     cancel: Cancel;
     blockCancel: Cancel;
-}) => Promise<BlockResult> | BlockResult;
+}) => Promise<NestedBlockParamsConstraint<BlockResult, Params>> | NestedBlockParamsConstraint<BlockResult, Params>;
 
 class FunctionBlock<
     Context,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,7 +68,7 @@ const array = function<
     Params = GetArrayBlockParams<Block>,
 >({ block, options }: {
     block: ArrayBlockDefinition<Block>;
-    options?: DescriptBlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
 }) {
     return new ArrayBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
 };
@@ -85,7 +85,7 @@ const object = function<
     Params = GetObjectBlockParams<Blocks>,
 >({ block, options }: {
     block?: ObjectBlockDefinition<Blocks>;
-    options?: DescriptBlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
 } = {}) {
     return new ObjectBlock<Context, Blocks, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
 };
@@ -121,7 +121,7 @@ const first = function<
     Params = GetFirstBlockParams<Block>,
 >({ block, options }: {
     block: FirstBlockDefinition<Block>;
-    options?: DescriptBlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
 }) {
     return new FirstBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
 };
@@ -138,7 +138,7 @@ const pipe = function<
     Params = GetPipeBlockParams<Block>,
 >({ block, options }: {
     block: PipeBlockDefinition<Block>;
-    options?: DescriptBlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
 }) {
     return new PipeBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,6 +28,7 @@ import type {
     InferBlock,
     InferHttpBlock,
     InferResultOrResult,
+    ExtractBadNestedParams,
 } from './types';
 import type BaseBlock from './block';
 import type { DescriptHttpBlockDescription, DescriptHttpBlockQuery, DescriptHttpBlockQueryValue } from './httpBlock';
@@ -51,7 +52,7 @@ const func = function<
     options?: DescriptBlockOptions<
         Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params
     >;
-}) {
+} & ([ ExtractBadNestedParams<BlockResult, ParamsOut> ] extends [ never ] ? unknown : ExtractBadNestedParams<BlockResult, ParamsOut>)) {
     return new FunctionBlock<
         Context, ParamsOut, BlockResult, ResultOut, BeforeResultOut, AfterResultOut, ErrorResultOut, Params
     >({ block, options });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -48,6 +48,20 @@ export type DescriptParamsError<Required, Available> = {
     readonly __fix: 'Add options.params to transform parent params into the required shape';
 };
 
+// Extracts DescriptParamsError for any block in T whose Params are not satisfied by the available Params.
+// Returns never when all blocks are compatible (no constraint added to the call site).
+export type ExtractBadNestedParams<T, Params> =
+    [ unknown ] extends [ Params ]
+        ? never
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        : T extends BaseBlock<any, any, any, any, any, any, any, any, any, infer BParams>
+            ? unknown extends BParams
+                ? never
+                : [ Params ] extends [ BParams ]
+                    ? never
+                    : DescriptParamsError<BParams, Params>
+            : never;
+
 export type DescriptJSON =
   boolean |
   number |

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,13 @@ export type NonNullableObject<T extends Record<string, unknown>> = {
     [P in keyof T]: Exclude<T[P], undefined>;
 };
 
+export type DescriptParamsError<Required, Available> = {
+    readonly __descriptError: 'NESTED_BLOCK_PARAMS_INCOMPATIBLE';
+    readonly __requiredParams: Required;
+    readonly __availableParams: Available;
+    readonly __fix: 'Add options.params to transform parent params into the required shape';
+};
+
 export type DescriptJSON =
   boolean |
   number |


### PR DESCRIPTION
This PR fixes #78

Кейсы, которые покрывает:
```ts
interface ParamsA {
    a: string;
}

interface ParamsB {
    b: number;
}

de.func({
    // ошибка: дочерний блок ожидает параметры ParamsB
    block: ({ params }: { params: ParamsA }) => {
        return de.http({
            block: {
                pathname: ({ params }: { params: ParamsB }) => `/resource/${params.b}`,
            },
        });
    },
});
```

```ts
const blockNeedsA = de.http({
    block: {
        pathname: ({ params }: { params: ParamsA }) => `/a/${params.a}`,
    },
});

const blockNeedsB = de.http({
    block: {
        pathname: ({ params }: { params: ParamsB }) => `/b/${params.b}`,
    },
});
de.func({
    block: ({ params }: { params: ParamsA }) => {
        return de.object({ // a так же array, first,  pipe
            block: {
                resA: blockNeedsA,
                resB: blockNeedsB, // требует ParamsB, которых нет в ParamsA
            },
        });
    },
});
```
```ts
de.object({
    options: {
        // ошибка:
        params: ({ params }: { params: ParamsA }) => {
            return params; // возвращает ParamsA, но нужно ParamsA & ParamsB
        },
    },
    block: {
        resA: blockNeedsA,
        resB: blockNeedsB,
    },
});
```
```ts
const blockTopLevel = de.func({
    block: ({ params }: { params: ParamsAB }) => {
        return de.http({
            block: {
                pathname: ({ params }: { params: ParamsAB }) => `/ab/${params.a}/${params.b}`,
            },
        });
    },
});

de.run(blockTopLevel, {
     // ошибка:
    params: { a: 'hello' },
});
```