### PR TITLE
required return types attempt 2 new generic

### DIFF
--- a/docs/typescript-examples/pipe.ts
+++ b/docs/typescript-examples/pipe.ts
@@ -67,13 +67,7 @@ const block3 = de.pipe({
             return params;
         },
         after: ({ result }) => {
-            if (typeof result === 'number') {
-                return result;
-            } else if ('b1' in result) {
-                return result.b1;
-            } else if ('b2' in result) {
-                return result.b2;
-            }
+            return result * 2;
         },
     },
 });

--- a/lib/arrayBlock.ts
+++ b/lib/arrayBlock.ts
@@ -15,10 +15,14 @@ import type Cancel from './cancel';
 import type { DescriptBlockDeps } from './depsDomain';
 import type DepsDomain from './depsDomain';
 
+type InferArrayElement<B> = B extends { readonly __isRequired: true }
+    ? InferResultFromBlock<B>
+    : InferResultFromBlock<B> | DescriptError;
+
 export type GetArrayBlockResult<T extends ReadonlyArray<unknown>> = {
     0: never;
-    1: [ InferResultFromBlock<First<T>> | DescriptError ];
-    2: [ InferResultFromBlock<First<T>> | DescriptError, ...GetArrayBlockResult<Tail<T>> ];
+    1: [ InferArrayElement<First<T>> ];
+    2: [ InferArrayElement<First<T>>, ...GetArrayBlockResult<Tail<T>> ];
 }[ T extends [] ? 0 : T extends ((readonly [ any ]) | [ any ]) ? 1 : 2 ];
 
 export type GetArrayBlockParamsUnion<T extends ReadonlyArray<unknown>> = {
@@ -57,6 +61,7 @@ class ArrayBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetArrayBlockParams<Block>,
+    IsRequired extends boolean = boolean,
 > extends CompositeBlock<
         Context,
         ArrayBlockDefinition<Block>,
@@ -68,7 +73,8 @@ class ArrayBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     extend<

--- a/lib/arrayBlock.ts
+++ b/lib/arrayBlock.ts
@@ -6,6 +6,7 @@ import type {
     First,
     InferResultFromBlock,
     InferParamsInFromBlock,
+    IsRequiredBlock,
     Tail,
     DescriptBlockOptions,
 } from './types';
@@ -15,7 +16,7 @@ import type Cancel from './cancel';
 import type { DescriptBlockDeps } from './depsDomain';
 import type DepsDomain from './depsDomain';
 
-type InferArrayElement<B> = B extends { readonly __isRequired: true }
+type InferArrayElement<B> = B extends IsRequiredBlock
     ? InferResultFromBlock<B>
     : InferResultFromBlock<B> | DescriptError;
 

--- a/lib/block.ts
+++ b/lib/block.ts
@@ -41,8 +41,10 @@ abstract class BaseBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = ParamsOut,
+    IsRequired extends boolean = boolean,
 > {
     declare readonly __resultType: InferResultOrResult<ResultOut>;
+    declare readonly __isRequired: IsRequired;
 
     protected block: CustomBlock;
     protected options: BlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;

--- a/lib/compositeBlock.ts
+++ b/lib/compositeBlock.ts
@@ -28,6 +28,7 @@ abstract class CompositeBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = ParamsOut,
+    IsRequired extends boolean = boolean,
 > extends BaseBlock<
         Context,
         CustomBlock,
@@ -39,7 +40,8 @@ abstract class CompositeBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     protected blocks: Array<{

--- a/lib/firstBlock.ts
+++ b/lib/firstBlock.ts
@@ -68,6 +68,7 @@ class FirstBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetFirstBlockParams<Block>,
+    IsRequired extends boolean = boolean,
 > extends CompositeBlock<
         Context,
         FirstBlockDefinition<Block>,
@@ -79,7 +80,8 @@ class FirstBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     extend<

--- a/lib/functionBlock.ts
+++ b/lib/functionBlock.ts
@@ -29,6 +29,7 @@ class FunctionBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = never extends InferParamsOutFromBlock<BlockResult> ? ParamsOut : InferParamsOutFromBlock<BlockResult>,
+    IsRequired extends boolean = boolean,
 > extends BaseBlock<
         Context,
         FunctionBlockDefinition<Context, ParamsOut, BlockResult>,
@@ -40,7 +41,8 @@ class FunctionBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     protected initBlock(block: FunctionBlockDefinition<Context, ParamsOut, BlockResult>) {
@@ -104,6 +106,7 @@ class FunctionBlock<
         ExtendedBeforeResultOut = unknown,
         ExtendedAfterResultOut = unknown,
         ExtendedErrorResultOut = unknown,
+        const ExtendedIsRequired extends boolean = IsRequired,
     >({ options }: {
         options: DescriptBlockOptions<
             Context,
@@ -113,14 +116,15 @@ class FunctionBlock<
             ExtendedAfterResultOut,
             ExtendedErrorResultOut,
             ExtendedParams
-        >;
+        > & { required?: ExtendedIsRequired };
     }) {
-        return new FunctionBlock({
-            block: this.extendBlock(this.block) as typeof this.block,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
-            options: this.extendOptions(this.options, options) as typeof options,
-        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = new FunctionBlock({ block: this.extendBlock(this.block) as any, options: this.extendOptions(this.options, options) as any });
+        return result as unknown as FunctionBlock<
+            Context, ExtendedParamsOut, ExtendedBlockResult,
+            BlockResultOut<ExtendedBlockResult, ExtendedBeforeResultOut, ExtendedAfterResultOut, ExtendedErrorResultOut>,
+            ExtendedBeforeResultOut, ExtendedAfterResultOut, ExtendedErrorResultOut, ExtendedParams, ExtendedIsRequired
+        >;
     }
 }
 

--- a/lib/httpBlock.ts
+++ b/lib/httpBlock.ts
@@ -188,6 +188,7 @@ class HttpBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = ParamsOut,
+    IsRequired extends boolean = boolean,
 > extends Block<
         Context,
         DescriptHttpBlockDescription<ParamsOut, Context, HttpResult>,
@@ -198,7 +199,8 @@ class HttpBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     extend<

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,14 +47,15 @@ const func = function<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = ParamsOut,
+    const IsRequired extends boolean = false,
 >({ block, options }: {
     block: FunctionBlockDefinition<Context, ParamsOut, BlockResult>;
     options?: DescriptBlockOptions<
         Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params
-    >;
+    > & { required?: IsRequired };
 } & ([ ExtractBadNestedParams<BlockResult, ParamsOut> ] extends [ never ] ? unknown : ExtractBadNestedParams<BlockResult, ParamsOut>)) {
     return new FunctionBlock<
-        Context, ParamsOut, BlockResult, ResultOut, BeforeResultOut, AfterResultOut, ErrorResultOut, Params
+        Context, ParamsOut, BlockResult, ResultOut, BeforeResultOut, AfterResultOut, ErrorResultOut, Params, IsRequired
     >({ block, options });
 };
 const array = function<
@@ -67,11 +68,12 @@ const array = function<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetArrayBlockParams<Block>,
+    const IsRequired extends boolean = false,
 >({ block, options }: {
     block: ArrayBlockDefinition<Block>;
-    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params> & { required?: IsRequired };
 }) {
-    return new ArrayBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
+    return new ArrayBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params, IsRequired>({ block, options });
 };
 const object = function<
     Context,
@@ -84,11 +86,12 @@ const object = function<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetObjectBlockParams<Blocks>,
+    const IsRequired extends boolean = false,
 >({ block, options }: {
     block?: ObjectBlockDefinition<Blocks>;
-    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params> & { required?: IsRequired };
 } = {}) {
-    return new ObjectBlock<Context, Blocks, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
+    return new ObjectBlock<Context, Blocks, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params, IsRequired>({ block, options });
 };
 const http = function<
     Context,
@@ -101,12 +104,13 @@ const http = function<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = ParamsOut,
+    const IsRequired extends boolean = false,
 >({ block, options }: {
     block?: DescriptHttpBlockDescription<ParamsOut, Context, IntermediateResult>;
-    options?: DescriptBlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params> & { required?: IsRequired };
 }) {
     return new HttpBlock<
-        Context, ParamsOut, IntermediateResult, ResultOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params
+        Context, ParamsOut, IntermediateResult, ResultOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params, IsRequired
     >({ block, options });
 };
 
@@ -120,11 +124,12 @@ const first = function<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetFirstBlockParams<Block>,
+    const IsRequired extends boolean = false,
 >({ block, options }: {
     block: FirstBlockDefinition<Block>;
-    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params> & { required?: IsRequired };
 }) {
-    return new FirstBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
+    return new FirstBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params, IsRequired>({ block, options });
 };
 
 const pipe = function<
@@ -137,11 +142,12 @@ const pipe = function<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetPipeBlockParams<Block>,
+    const IsRequired extends boolean = false,
 >({ block, options }: {
     block: PipeBlockDefinition<Block>;
-    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>;
+    options?: DescriptBlockOptions<Context, NoInfer<ParamsOut>, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params> & { required?: IsRequired };
 }) {
-    return new PipeBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params>({ block, options });
+    return new PipeBlock<Context, Block, ResultOut, ParamsOut, BlockResult, BeforeResultOut, AfterResultOut, ErrorResultOut, Params, IsRequired>({ block, options });
 };
 
 const isBlock = function(block: any) {

--- a/lib/objectBlock.ts
+++ b/lib/objectBlock.ts
@@ -2,7 +2,7 @@ import CompositeBlock from './compositeBlock';
 import type { DescriptError } from './error';
 import { createError, ERROR_ID } from './error';
 import type BaseBlock from './block';
-import type { InferParamsInFromBlock, DescriptBlockOptions, BlockResultOut, UnionToIntersection, InferResultFromBlock } from './types';
+import type { InferParamsInFromBlock, DescriptBlockOptions, BlockResultOut, UnionToIntersection, InferResultFromBlock, IsRequiredBlock } from './types';
 import type ContextClass from './context';
 import type Cancel from './cancel';
 import type { DescriptBlockDeps } from './depsDomain';
@@ -18,7 +18,7 @@ export type InferResultFromObjectBlocks<Block> = Block extends BaseBlock<
     Block;
 
 export type GetObjectBlockResult<T extends Record<string, any>> = {
-    [ P in keyof T ]: T[P] extends { readonly __isRequired: true }
+    [ P in keyof T ]: T[P] extends IsRequiredBlock
         ? InferResultFromBlock<T[P]>
         : InferResultFromBlock<T[P]> | DescriptError
 };

--- a/lib/objectBlock.ts
+++ b/lib/objectBlock.ts
@@ -18,7 +18,9 @@ export type InferResultFromObjectBlocks<Block> = Block extends BaseBlock<
     Block;
 
 export type GetObjectBlockResult<T extends Record<string, any>> = {
-    [ P in keyof T ]: InferResultFromBlock<T[P]> | DescriptError
+    [ P in keyof T ]: T[P] extends { readonly __isRequired: true }
+        ? InferResultFromBlock<T[P]>
+        : InferResultFromBlock<T[P]> | DescriptError
 };
 
 export type GetObjectBlockParams<
@@ -50,6 +52,7 @@ class ObjectBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetObjectBlockParams<Blocks>,
+    IsRequired extends boolean = boolean,
 > extends CompositeBlock<
         Context,
         ObjectBlockDefinition<Blocks>,
@@ -61,7 +64,8 @@ class ObjectBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     protected initBlock(object: ObjectBlockDefinition<Blocks>) {

--- a/lib/pipeBlock.ts
+++ b/lib/pipeBlock.ts
@@ -68,6 +68,7 @@ class PipeBlock<
     AfterResultOut = unknown,
     ErrorResultOut = unknown,
     Params = GetPipeBlockParams<Block>,
+    IsRequired extends boolean = boolean,
 > extends CompositeBlock<
         Context,
         PipeBlockDefinition<Block>,
@@ -79,7 +80,8 @@ class PipeBlock<
         BeforeResultOut,
         AfterResultOut,
         ErrorResultOut,
-        Params
+        Params,
+        IsRequired
     > {
 
     extend<

--- a/lib/pipeBlock.ts
+++ b/lib/pipeBlock.ts
@@ -1,10 +1,10 @@
 import CompositeBlock from './compositeBlock';
 import { ERROR_ID, createError } from './error';
-import type { DescriptError } from './error';
 import type BaseBlock from './block';
 import type {
     BlockResultOut,
     First,
+    Last,
     InferResultFromBlock,
     InferParamsInFromBlock,
     Tail,
@@ -32,12 +32,6 @@ export type GetPipeBlockParams<
     PU = GetPipeBlockParamsUnion<PA>,
 > = PU;
 
-type GetPipeBlockResultUnion<T extends ReadonlyArray<unknown>> = {
-    0: never;
-    1: First<T> | DescriptError;
-    2: First<T> | DescriptError | GetPipeBlockResultUnion<Tail<T>>;
-}[ T extends [] ? 0 : T extends ((readonly [ any ]) | [ any ]) ? 1 : 2 ];
-
 type GetPipeBlockResultMap<T extends ReadonlyArray<unknown>> = {
     [ P in keyof T ]: InferResultFromBlock<T[ P ]>;
 };
@@ -45,8 +39,7 @@ type GetPipeBlockResultMap<T extends ReadonlyArray<unknown>> = {
 export type GetPipeBlockResult<
     T extends ReadonlyArray<unknown>,
     PA extends ReadonlyArray<unknown> = GetPipeBlockResultMap<T>,
-    PU = GetPipeBlockResultUnion<PA>,
-> = PU;
+> = Last<PA>;
 
 export type PipeBlockDefinition<T> = {
     [ P in keyof T ]: T[ P ] extends BaseBlock<

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -111,6 +111,18 @@ export type InferResultFromBlock<Type> = Type extends BaseBlock<
     infer BlockResult, infer BeforeResultOut, infer AfterResultOut, infer ErrorResultOut, infer Params
 > ? InferResultOrResult<ResultOut> : never;
 
+export type DeepResolveResult<T> =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    T extends BaseBlock<any, any, any, infer ResultOut, any, any, any, any, any, any>
+        ? DeepResolveResult<InferResultOrResult<ResultOut>>
+        : T extends DescriptError
+            ? DescriptError
+            : T extends Record<string, unknown>
+                ? { [K in keyof T]: DeepResolveResult<T[K]> }
+                : T;
+
+export type DeepInferResultFromBlock<T> = DeepResolveResult<InferResultFromBlock<T>>;
+
 export type InferParamsInFromBlock<Type> = Type extends BaseBlock<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     infer Context, infer CustomBlock, infer ParamsOut, infer ResultOut, infer IntermediateResult,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -175,6 +175,10 @@ export type Tail<T> =
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
     T extends readonly [ infer First, ...infer Rest ] | [ infer First, ...infer Rest ] ? Rest : never;
 
+export type Last<T> =
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+    T extends readonly [ ...infer Rest, infer L ] | [ ...infer Rest, infer L ] ? L : never;
+
 export type Equal<A, B> = A extends B ? (B extends A ? A : never) : never;
 
 export type DepsIds = Array<DescriptBlockId<any> | UntypedId>;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -104,6 +104,8 @@ export type InferResultOrResultOnce<Result> = Result extends BaseBlock<
     infer BlockResult, infer BeforeResultOut, infer AfterResultOut, infer ErrorResultOut, infer Params
 > ? ResultOut : Result;
 
+export type IsRequiredBlock = { readonly __isRequired: true };
+
 export type InferResultFromBlock<Type> = Type extends BaseBlock<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     infer Context, infer CustomBlock, infer ParamsOut, infer ResultOut, infer IntermediateResult,

--- a/tests/options.required.test.ts
+++ b/tests/options.required.test.ts
@@ -6,6 +6,7 @@ import * as de from '../lib';
 import { DescriptError } from '../lib';
 import { getPath } from './helpers';
 import Server from './server';
+import type { Expect, TypesMatch } from './test.types';
 
 const PORT = 10000;
 const fake = new Server({
@@ -179,5 +180,56 @@ describe('options.required', () => {
 
         const childHeaders = spy.mock.calls[ 0 ][ 0 ].headers;
         expect(childHeaders[ 'x-required-header' ]).toBe('true');
+    });
+
+    it('types: required=true removes DescriptError from object block result', async() => {
+        const block = de.object({
+            block: {
+                foo: de.func({
+                    block: () => 42,
+                    options: {
+                        required: true,
+                    },
+                }),
+                bar: de.func({
+                    block: () => 'hello',
+                    options: {
+                        required: true,
+                    },
+                }),
+            },
+        });
+
+        const result = await de.run(block, { params: {} });
+
+        expect(result.foo).toBe(42);
+        expect(result.bar).toBe('hello');
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Tests = [
+            Expect<TypesMatch<typeof result, { foo: number; bar: string }>>,
+        ];
+    });
+
+    it('types: required=false keeps DescriptError in object block result', async() => {
+        const block = de.object({
+            block: {
+                foo: de.func({
+                    block: () => 42,
+                    options: {
+                        required: false,
+                    },
+                }),
+            },
+        });
+
+        const result = await de.run(block, { params: {} });
+
+        expect(result.foo).toBe(42);
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Tests = [
+            Expect<TypesMatch<typeof result, { foo: number | DescriptError }>>,
+        ];
     });
 });

--- a/tests/pipeBlock.test.ts
+++ b/tests/pipeBlock.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import * as de from '../lib';
+import type { Expect, TypesMatch } from './test.types';
 
 describe('de.pipe', () => {
 
@@ -113,6 +114,31 @@ describe('de.pipe', () => {
             expect(e).toBe(error);
             expect(spy1.mock.calls).toHaveLength(1);
         }
+    });
+
+    it('types: result type is the last block result type', async() => {
+        const block1 = de.func({
+            block: () => 42,
+        });
+        const block2 = de.func({
+            block: () => 'hello',
+        });
+        const block3 = de.func({
+            block: () => true,
+        });
+
+        const block = de.pipe({
+            block: [ block1, block2, block3 ],
+        });
+
+        const result = await de.run(block, { params: {} });
+
+        expect(typeof result).toBe('boolean');
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Tests = [
+            Expect<TypesMatch<typeof result, boolean>>,
+        ];
     });
 
 });


### PR DESCRIPTION
This pr fixes #80 
- Добавлена обработка required: true, теперь, если required: true, в типах не будет DescriptError
- Добавлен DeepInferResultFromBlock - возвращает результат выполнения блока рекурсивно
- Исправлен вывод типов блока pipe - теперь результат pipe - это результат последнего блока цепочки как и в рантайме